### PR TITLE
fix(profilarr): drop invalid v-prefix from image tag

### DIFF
--- a/kubernetes/apps/default/profilarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/profilarr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dictionarry-hub/profilarr
-              tag: v2.2.0@sha256:ddcdd0f340043c2ec0a85ca74b9a6be9be42b1c0288c75fc36a26a43f695860b
+              tag: 2.2.0@sha256:ddcdd0f340043c2ec0a85ca74b9a6be9be42b1c0288c75fc36a26a43f695860b
             env:
               TZ: America/Boise
               PUID: 1000


### PR DESCRIPTION
The tag v2.2.0 does not exist on ghcr.io/dictionarry-hub/profilarr (upstream publishes tags without the v prefix), which caused Renovate to fail digest lookups. The pinned digest already matches tag 2.2.0, so this is a no-op for the running deployment.