### PR TITLE
fix(renovate): stop treating OCHARTED_USERNAME as a secret

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -52,7 +52,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           GITHUB_BOT_APP_CLIENT_ID: op://kube-secrets/github-bot/GITHUB_BOT_APP_CLIENT_ID
           GITHUB_BOT_APP_PRIVATE_KEY: op://kube-secrets/github-bot/GITHUB_BOT_APP_PRIVATE_KEY
-          OCHARTED_USERNAME: op://kube-secrets/ocharted/OCHARTED_USERNAME
           OCHARTED_PASSWORD: op://kube-secrets/ocharted/OCHARTED_PASSWORD
 
       - name: Generate Token
@@ -87,7 +86,6 @@ jobs:
           RENOVATE_PLATFORM_COMMIT: true
           RENOVATE_SECRETS: |-
             {
-              "OCHARTED_USERNAME": "jimmy",
               "OCHARTED_PASSWORD": "${{ steps.load-secrets.outputs.OCHARTED_PASSWORD }}"
             }
         with:


### PR DESCRIPTION
## Problem

Renovate was silently refusing to update `ghcr.io/jimmy-ungerman/psu-parlay` on every run since Aug 17, logging only a DEBUG-level `Secrets exposed in commit message` and skipping branch/PR creation — no dashboard warning, nothing.

Root cause: `RENOVATE_SECRETS` passed `OCHARTED_USERNAME` ("jimmy") through as a value to redact. Renovate's `applySecretsAndVariablesToConfig()` registers *every* value in `RENOVATE_SECRETS` for sanitizing unconditionally, regardless of whether it's referenced anywhere via `{{ secrets.X }}`. Since the depName `ghcr.io/jimmy-ungerman/psu-parlay` contains "jimmy", every generated commit message/branch name for that package tripped the leak-protection check.

`.renovaterc.json5` was already updated in a prior commit to hardcode `username: "jimmy"` directly instead of templating it from secrets — but the workflow's `RENOVATE_SECRETS` blob still carried the old value, so the collision persisted.

## Fix

- Drop `OCHARTED_USERNAME` from the `RENOVATE_SECRETS` JSON — only `OCHARTED_PASSWORD` is still referenced via template.
- Drop the now-unused `OCHARTED_USERNAME` line from the 1Password `Load Secrets` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)